### PR TITLE
Replace maven plugin with maven-publish

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ def safeExtGet(prop, fallback) {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
@@ -45,7 +45,7 @@ apply plugin: 'com.android.library'
 if (project == rootProject) {
     apply plugin: 'de.mannodermaus.android-junit5'
 }
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 
 android {
@@ -91,34 +91,6 @@ dependencies {
     }
 }
 
-def configureReactNativePom(def pom) {
-    def packageJson = new JsonSlurper().parseText(file('../package.json').text)
-
-    pom.project {
-        name packageJson.title
-        artifactId packageJson.name
-        version = packageJson.version
-        group = "com.reactlibrary"
-        description packageJson.description
-        url packageJson.repository.baseUrl
-
-        licenses {
-            license {
-                name packageJson.license
-                url packageJson.repository.baseUrl + '/blob/master/' + packageJson.licenseFilename
-                distribution 'repo'
-            }
-        }
-
-        developers {
-            developer {
-                id packageJson.author.username
-                name packageJson.author.name
-            }
-        }
-    }
-}
-
 afterEvaluate { project ->
     // some Gradle build hooks ref:
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
@@ -154,12 +126,11 @@ afterEvaluate { project ->
         archives androidJavadocJar
     }
 
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-            configureReactNativePom pom
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                artifact androidSourcesJar
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
The `maven` plugin has been deprecated since gradle 6.0 and was removed in gradle 7.0. This PR will update `react-native-hash` to use `maven-publish` instead of `maven` so it will work with gradle versions >= 7.0. 
React Native 0.67.1 uses Gradle 7.2. 

Fixes issue #40 
Has been mildly tested with my apps, please test thoroughly.

### Changes
Changed `android/build.gradle` to make it work with `maven-publish`.